### PR TITLE
Reduces memory allocation via pooling and fixes race condition

### DIFF
--- a/core/src/SSRAG/Datory/DistributedCache.Public.cs
+++ b/core/src/SSRAG/Datory/DistributedCache.Public.cs
@@ -39,42 +39,33 @@ namespace SSRAG.Datory
 
             // 2. 获取或创建锁，防止缓存击穿
             var lockKey = $"lock:{key}";
-            var semaphore = _locks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
+            using var _ = await _locks.LockAsync(lockKey).ConfigureAwait(false);
 
-            await semaphore.WaitAsync();
-            try
+            // 3. 再次检查本地缓存（可能在等待期间已被其他线程填充）
+            if (_memoryCache.TryGetValue(key, out value))
             {
-                // 3. 再次检查本地缓存（可能在等待期间已被其他线程填充）
-                if (_memoryCache.TryGetValue(key, out value))
-                {
-                    return value;
-                }
-
-                // 4. 从Redis获取
-
-                var redisValue = await StringGetAsync(key);
-                if (!string.IsNullOrEmpty(redisValue))
-                {
-                    value = TranslateUtils.JsonDeserialize<T>(redisValue);
-                    _memoryCache.Set(key, value, TimeSpan.FromMinutes(Constants.DefaultMemoryExpireMinutes));
-                    return value;
-                }
-
-                // 5. 如果Redis中也没有，则调用工厂方法生成数据
-                value = await factory();
-                if (value == null) return default;
-
-                // 6. 同时写入本地缓存和Redis
-                _memoryCache.Set(key, value, TimeSpan.FromMinutes(Constants.DefaultMemoryExpireMinutes));
-                await StringSetAsync(key, TranslateUtils.JsonSerialize(value));
-
                 return value;
             }
-            finally
+
+            // 4. 从Redis获取
+
+            var redisValue = await StringGetAsync(key);
+            if (!string.IsNullOrEmpty(redisValue))
             {
-                semaphore.Release();
-                _locks.TryRemove(lockKey, out _);
+                value = TranslateUtils.JsonDeserialize<T>(redisValue);
+                _memoryCache.Set(key, value, TimeSpan.FromMinutes(Constants.DefaultMemoryExpireMinutes));
+                return value;
             }
+
+            // 5. 如果Redis中也没有，则调用工厂方法生成数据
+            value = await factory();
+            if (value == null) return default;
+
+            // 6. 同时写入本地缓存和Redis
+            _memoryCache.Set(key, value, TimeSpan.FromMinutes(Constants.DefaultMemoryExpireMinutes));
+            await StringSetAsync(key, TranslateUtils.JsonSerialize(value));
+
+            return value;
         }
 
         public async Task RemoveAsync(string key)
@@ -103,33 +94,24 @@ namespace SSRAG.Datory
 
             // 2. 获取或创建锁，防止缓存击穿
             var lockKey = $"lock:{key}";
-            var semaphore = _locks.GetOrAdd(lockKey, _ => new SemaphoreSlim(1, 1));
+            using var _ = await _locks.LockAsync(lockKey).ConfigureAwait(false);
 
-            await semaphore.WaitAsync();
-            try
+            // 3. 再次检查本地缓存（可能在等待期间已被其他线程填充）
+            if (_memoryCache.TryGetValue(key, out value))
             {
-                // 3. 再次检查本地缓存（可能在等待期间已被其他线程填充）
-                if (_memoryCache.TryGetValue(key, out value))
-                {
-                    return value;
-                }
-
-                // 4. 从Redis获取
-                var redisValue = await StringGetAsync(key);
-                if (!string.IsNullOrEmpty(redisValue))
-                {
-                    value = redisValue;
-                    _memoryCache.Set(key, value, TimeSpan.FromMinutes(Constants.DefaultMemoryExpireMinutes));
-                    return value;
-                }
-
-                return string.Empty;
+                return value;
             }
-            finally
+
+            // 4. 从Redis获取
+            var redisValue = await StringGetAsync(key);
+            if (!string.IsNullOrEmpty(redisValue))
             {
-                semaphore.Release();
-                _locks.TryRemove(lockKey, out _);
+                value = redisValue;
+                _memoryCache.Set(key, value, TimeSpan.FromMinutes(Constants.DefaultMemoryExpireMinutes));
+                return value;
             }
+
+            return string.Empty;
         }
 
         public async Task<bool> SetStringAsync(string key, string value, int minutes = 0)

--- a/core/src/SSRAG/Datory/DistributedCache.cs
+++ b/core/src/SSRAG/Datory/DistributedCache.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Caching.Memory;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Collections.Generic;
+using AsyncKeyedLock;
 using SSRAG.Datory.Utils;
 
 namespace SSRAG.Datory
@@ -13,7 +14,7 @@ namespace SSRAG.Datory
         private readonly string _prefix;
         private readonly MemoryCache _memoryCache;
         private readonly Lazy<ConnectionMultiplexer> _lazyConnection;
-        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+        private static readonly AsyncKeyedLocker<string> _locks = new();
 
         public DistributedCache(string connectionString)
         {

--- a/core/src/SSRAG/SSRAG.csproj
+++ b/core/src/SSRAG/SSRAG.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/core/src/SSRAG/SSRAG.csproj
+++ b/core/src/SSRAG/SSRAG.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncKeyedLock" Version="7.1.8" />
+    <PackageReference Include="AsyncKeyedLock" Version="8.0.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.41" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.115.5" />
     <PackageReference Include="Dapper" Version="2.0.123" />


### PR DESCRIPTION
Thread A locks on key ABC and is processing
Thread B obtains locks for key ABC and is waiting for thread A to finish
Thread A finishes and removes the lock from the dictionary, while thread B enters the lock
Thread C tries to lock on key ABC but the entry was deleted by thread A, therefore threads B and C process concurrently despite that they share the same key.

This PR fixes this issue and also uses pooled semaphoreslim objects to reduce allocations.